### PR TITLE
Add startup docs and env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DATABASE_URL="mysql://username:password@localhost:3306/singitronic_nextjs"
+NEXTAUTH_SECRET="your_nextauth_secret"
+NEXTAUTH_URL=http://localhost:3000
+PORT=3001

--- a/README.md
+++ b/README.md
@@ -1,3 +1,28 @@
+## Quick Start
+
+1. Copy `.env.example` to `.env` in the project root and also copy it to `server/.env`.
+2. Update `DATABASE_URL` and other values in both `.env` files.
+3. Install dependencies:
+   ```bash
+   npm install
+   cd server && npm install
+   ```
+4. Run database migrations and seed demo data:
+   ```bash
+   npx prisma migrate dev
+   cd utils && node insertDemoData.js
+   cd ..
+   ```
+5. Start the backend server:
+   ```bash
+   node app.js
+   ```
+6. In another terminal start the Next.js app from the project root:
+   ```bash
+   npm run dev
+   ```
+
+---
 <h1>Electronics eCommerce Shop With Admin Dashboard in Next.js and Node.js</h1>
 
 <p><b>Electronics eCommerce shop with admin dashboard in Next.js and Node.js</b> is a <b>free eCommerce store</b> developed using Next.js, Node.js and MySQL. The application is completely built from scratch(custom design) and completely responsive.


### PR DESCRIPTION
## Summary
- add quick start instructions to README
- provide .env.example with default variables

## Testing
- `npm install`
- `npm run build` *(fails due to manual interruption)*

------
https://chatgpt.com/codex/tasks/task_e_6859c923dba0832285bf9f511f0c4a42