### PR TITLE
Add fetchFromServer with network fallback

### DIFF
--- a/lib/fetchFromServer.ts
+++ b/lib/fetchFromServer.ts
@@ -1,0 +1,14 @@
+const BASE_URL = process.env.SERVER_URL || 'http://localhost:3001';
+
+export async function fetchFromServer(path: string, options?: RequestInit) {
+  try {
+    const res = await fetch(`${BASE_URL}${path}`, options);
+    if (!res.ok) return {};
+    return await res.json();
+  } catch (err) {
+    console.error('Network request failed', err);
+    return {};
+  }
+}
+
+export default fetchFromServer;


### PR DESCRIPTION
## Summary
- centralize server fetch logic in `fetchFromServer`
- return an empty object when a request fails

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859cdbd9ba08322bca73a70ae61e3ee